### PR TITLE
fix(release): inline prepare metadata, drop alef dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,38 @@ jobs:
       release_node: ${{ steps.metadata.outputs.release_node }}
       release_go: ${{ steps.metadata.outputs.release_go }}
     steps:
-      - uses: kreuzberg-dev/actions/prepare-release-metadata@v1
+      - name: Extract release metadata
         id: metadata
-        with:
-          available-targets: "python,node,go"
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_FORCE_REPUBLISH: ${{ inputs.force_republish }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([-+][A-Za-z0-9.+-]+)?$ ]]; then
+            echo "tag '$tag' does not match v<semver>" >&2
+            exit 1
+          fi
+          version="${tag#v}"
+          if [[ "$version" =~ -(rc|alpha|beta|pre|dev) ]]; then
+            npm_tag="next"
+          else
+            npm_tag="latest"
+          fi
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "npm_tag=$npm_tag"
+            echo "dry_run=${INPUT_DRY_RUN:-false}"
+            echo "force_republish=${INPUT_FORCE_REPUBLISH:-false}"
+            echo "release_python=true"
+            echo "release_node=true"
+            echo "release_go=true"
+          } >> "$GITHUB_OUTPUT"
+          echo "tag=$tag version=$version npm_tag=$npm_tag dry_run=${INPUT_DRY_RUN:-false} force_republish=${INPUT_FORCE_REPUBLISH:-false}"
 
   validate-versions:
     needs: prepare


### PR DESCRIPTION
## Summary

The v0.0.1 release run failed at the `prepare` job: `prepare-release-metadata@v1` installs alef from `kreuzberg-dev/alef` releases and gets a 404 (asset not publicly available). All downstream jobs were skipped.

## Fix

Replace the action call with an inline bash step that produces the same output surface (`tag`, `version`, `npm_tag`, `dry_run`, `force_republish`, `release_{python,node,go}`). The SDK always publishes all three targets together, so alef's per-target gating isn't needed.

## Recovery plan after merge

1. Delete the existing `v0.0.1` tag + release (no actual publish happened).
2. Recreate the release at the new HEAD of `main` (with this fix) — re-triggers `release.yml`.

## Test plan

- [ ] CI green on this PR (validate workflow + actionlint).
- [ ] After merge: re-trigger release pipeline by recreating `v0.0.1`.