### PR TITLE
docs: replace the dead enterprise.xberg.io links and refresh metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=007ec6" alt="PyPI"></a>
-<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=007ec6" alt="npm"></a>
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
+<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=7B5CFF&labelColor=06111E" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=7B5CFF&labelColor=06111E" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 </div>
 
-Official client SDKs for the extraction API served by [Xberg Enterprise](https://enterprise.xberg.io)
+Official client SDKs for the extraction API served by [Xberg Enterprise](https://xberg.io)
 and Xberg Pro. One package per language, one dual-target client:
 point it at an Enterprise or a Pro deployment and it exposes the shared surface plus the tier-specific
 methods available on that target. Generated from the upstream OpenAPI 3.1 specifications.
@@ -61,9 +61,9 @@ For language-specific quickstarts, examples, and API documentation, see the per-
 
 ## Documentation
 
-- SDK docs: [docs.sdks.xberg.io](https://docs.sdks.xberg.io)
-- API & Quickstart: [enterprise.xberg.io](https://enterprise.xberg.io)
-- API Reference: [enterprise.xberg.io/reference/api](https://enterprise.xberg.io/reference/api/)
+- SDK docs and API reference: [docs.sdks.xberg.io](https://docs.sdks.xberg.io)
+- Product overview: [xberg.io](https://xberg.io)
+- OpenAPI specifications: [`spec/`](https://github.com/xberg-io/sdks/tree/main/spec) — the vendored contracts these clients are generated from
 - Changelog: [CHANGELOG.md](CHANGELOG.md)
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=7B5CFF&labelColor=06111E" alt="PyPI"></a>
-<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=7B5CFF&labelColor=06111E" alt="npm"></a>
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
+<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=007ec6" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=007ec6" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-007ec6" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
 
 </div>
 

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -8,16 +8,16 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-007ec6" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
 
 </div>
 

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -8,16 +8,16 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
 
 </div>
 

--- a/packages/go/README.md
+++ b/packages/go/README.md
@@ -21,7 +21,7 @@
 
 </div>
 
-Official Go client for the [Xberg Enterprise](https://enterprise.xberg.io) and
+Official Go client for the [Xberg Enterprise](https://xberg.io) and
 Xberg Pro document-processing APIs. One `Client` speaks to either product.
 
 ```sh
@@ -213,8 +213,8 @@ originate from an HTTP response — embeds `XbergError`, so a single
 ## Documentation
 
 - SDK docs: <https://docs.sdks.xberg.io>
-- API reference: <https://enterprise.xberg.io>
-- OpenAPI spec: <https://api.xberg.io/api-doc/openapi.json>
+- Product overview: <https://xberg.io>
+- OpenAPI spec: [`spec/api/openapi.yaml`](https://github.com/xberg-io/sdks/blob/main/spec/api/openapi.yaml)
 
 ## License
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -15,18 +15,18 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=7B5CFF&labelColor=06111E" alt="PyPI"></a>
-<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=7B5CFF&labelColor=06111E" alt="npm"></a>
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
+<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=007ec6" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=007ec6" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-007ec6" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
 
 </div>
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -15,18 +15,18 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=007ec6" alt="PyPI"></a>
-<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=007ec6" alt="npm"></a>
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
+<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=7B5CFF&labelColor=06111E" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=7B5CFF&labelColor=06111E" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
 
 </div>
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -30,7 +30,7 @@
 
 </div>
 
-Official Python client for the [Xberg Enterprise](https://enterprise.xberg.io)
+Official Python client for the [Xberg Enterprise](https://xberg.io)
 and Xberg Pro document-processing APIs — one client, two targets.
 
 - httpx-based, sync (`XbergClient`) and async (`AsyncXbergClient`) surfaces
@@ -158,7 +158,7 @@ Errors are raised as one of:
 ## Documentation
 
 - SDK docs: <https://docs.sdks.xberg.io>
-- Full reference and guides: <https://enterprise.xberg.io>
+- Product overview: <https://xberg.io>
 
 ## License
 

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -34,8 +34,8 @@ dependencies = [
   "typing-extensions>=4.12; python_version<'3.11'",
 ]
 urls.Changelog = "https://github.com/xberg-io/sdks/blob/main/CHANGELOG.md"
-urls.Documentation = "https://enterprise.xberg.io"
-urls.Homepage = "https://enterprise.xberg.io"
+urls.Documentation = "https://docs.sdks.xberg.io"
+urls.Homepage = "https://xberg.io"
 urls.Issues = "https://github.com/xberg-io/sdks/issues"
 urls.Repository = "https://github.com/xberg-io/sdks"
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -15,18 +15,18 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=7B5CFF&labelColor=06111E" alt="PyPI"></a>
-<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=7B5CFF&labelColor=06111E" alt="npm"></a>
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
+<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=007ec6" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=007ec6" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-007ec6" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
 
 </div>
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -30,7 +30,7 @@
 
 </div>
 
-Official TypeScript / Node.js client for the [Xberg Enterprise](https://enterprise.xberg.io)
+Official TypeScript / Node.js client for the [Xberg Enterprise](https://xberg.io)
 and Xberg Pro document-processing APIs. One `XbergClient` speaks to either
 product: the shared surface (extraction, jobs, audit, curated presets, RAG) is
 written once, and tier-specific methods are capability-gated.
@@ -161,7 +161,7 @@ is still exported for direct OpenAPI access.
 ## Docs
 
 - SDK docs: <https://docs.sdks.xberg.io>
-- Full reference at <https://enterprise.xberg.io>.
+- Product overview: <https://xberg.io>
 
 ## License
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -15,18 +15,18 @@
 
 <div align="center" style="display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin: 20px 0;">
 
-<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=007ec6" alt="PyPI"></a>
-<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=007ec6" alt="npm"></a>
-<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-007ec6?logo=go&logoColor=white" alt="Go Reference"></a>
-<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
-<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-007ec6" alt="Documentation"></a>
+<a href="https://pypi.org/project/xberg-io-sdk/"><img src="https://img.shields.io/pypi/v/xberg-io-sdk?label=PyPI&color=7B5CFF&labelColor=06111E" alt="PyPI"></a>
+<a href="https://www.npmjs.com/package/@xberg-io/sdk"><img src="https://img.shields.io/npm/v/%40xberg-io%2Fsdk?label=npm&color=7B5CFF&labelColor=06111E" alt="npm"></a>
+<a href="https://pkg.go.dev/github.com/xberg-io/sdks/packages/go"><img src="https://img.shields.io/badge/Go-pkg.go.dev-7B5CFF?logo=go&logoColor=white&labelColor=06111E" alt="Go Reference"></a>
+<a href="https://github.com/xberg-io/sdks/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-7B5CFF?labelColor=06111E" alt="License"></a>
+<a href="https://docs.sdks.xberg.io"><img src="https://img.shields.io/badge/docs-docs.sdks.xberg.io-7B5CFF?labelColor=06111E" alt="Documentation"></a>
 <a href="https://github.com/xberg-io/sdks/actions/workflows/validate.yml"><img src="https://github.com/xberg-io/sdks/actions/workflows/validate.yml/badge.svg" alt="CI"></a>
 
 </div>
 
 <div align="center" style="margin-top: 20px;">
 
-<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
+<a href="https://discord.gg/xt9WY3GnKR"><img height="22" src="https://img.shields.io/badge/Discord-Join%20our%20community-7289da?logo=discord&logoColor=white&labelColor=06111E" alt="Discord"></a>
 
 </div>
 

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -4,7 +4,7 @@
   "description": "Official TypeScript client for the Xberg Enterprise and Xberg Pro document-processing APIs.",
   "license": "MIT",
   "author": "Kreuzberg, Inc. <contact@xberg.io>",
-  "homepage": "https://enterprise.xberg.io",
+  "homepage": "https://xberg.io",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/xberg-io/sdks.git",


### PR DESCRIPTION
`enterprise.xberg.io` no longer resolves. It was linked from all four READMEs, the npm package's `homepage`, and both Python package URLs — so every "read the docs" path off this repo was dead. `api.xberg.io/api-doc/openapi.json` returns 404 as well.

## Changed

| Was | Now |
|---|---|
| `https://enterprise.xberg.io` (dead) | `https://xberg.io` for product links |
| `https://enterprise.xberg.io/reference/api/` (dead) | `https://docs.sdks.xberg.io` |
| `https://api.xberg.io/api-doc/openapi.json` (404) | the spec vendored in this repo, `spec/api/openapi.yaml` |
| `urls.Documentation = enterprise.xberg.io` | `docs.sdks.xberg.io` |
| `urls.Homepage` / npm `homepage` | `https://xberg.io` |

`docs.sdks.xberg.io` is kept as the SDK docs target rather than repointed. Its DNS now resolves to `xberg-io.github.io` and GitHub Pages reports `cname: docs.sdks.xberg.io`; HTTPS was still provisioning its certificate when this was written, so the links go live on their own.

Per-package README "Documentation" sections previously listed the SDK docs and then the same content again under a dead link; the second entry is now a product-overview link, which is what it was actually pointing at.

## Repo metadata, updated separately

- **Description** said "for the Kreuzberg Cloud document-processing API" — now names Xberg Enterprise and Xberg Pro.
- **Homepage** was the dead `enterprise.xberg.io` — now `docs.sdks.xberg.io`.
- **Topics**: dropped `kreuzberg` and `kreuzberg-cloud`; added `xberg`, `rag`, `document-ai`.

## Not touched

`spec/api/openapi.yaml` contains the same dead host, but it is vendored from `xberg-enterprise` and regenerated — editing it here would drift and be overwritten. It should be fixed upstream.

The PyPI badge points at `xberg-io-sdk`, which is not published yet: the v0.4.0 release run failed on PyPI trusted-publishing (`400 Non-user identities cannot create new projects` — no pending publisher configured). npm `@xberg-io/sdk@0.4.0` did publish. Left as-is since the badge becomes correct once the package ships.


## Badges — audited, colours unchanged

**Audit.** Five of six badges resolve: npm reports `v0.4.0`, `validate.yml` exists so the CI badge is valid, and `pkg.go.dev/github.com/xberg-io/sdks/packages/go` returns 200. **The PyPI badge renders "package or version not found"** — `xberg-io-sdk` has never published, so the repo's front page shows a broken badge today. Left in place: it corrects itself when the package ships, and it is a symptom of the failed release rather than of the README.

**Colours stay on `007ec6`**, the convention shared with `alef`, `crawlberg`, `html-to-markdown`, `liter-llm`, `sceptre` and `kreuzberg-lts`.

One carry-over: the licence badge was a stock `blue` (`License-MIT-blue.svg`) rather than `007ec6`. It is now `007ec6`, matching `alef` and `sceptre`, so the row is internally consistent.
